### PR TITLE
Format codes and fix Clippy warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
     let lines: Vec<_> = test_case_definitions.lines().map(|l| l.unwrap()).collect();
 
     for i in 1..lines.len() - 1 {
-        if lines[i].starts_with("_R") && lines[i - 1].starts_with("#") {
+        if lines[i].starts_with("_R") && lines[i - 1].starts_with('#') {
             let title_line = &lines[i - 1];
             let spec_line = &lines[i];
             emit_test_case(spec_line, title_line, &mut output);
@@ -24,7 +24,7 @@ fn main() {
 }
 
 fn emit_test_case(spec_line: &str, title_line: &str, output: &mut impl Write) {
-    if spec_line.starts_with("_R") && title_line.starts_with("#") {
+    if spec_line.starts_with("_R") && title_line.starts_with('#') {
         let end_of_mangled_name = spec_line.find(' ').unwrap();
         let mangled = &spec_line[..end_of_mangled_name];
         let demangled = spec_line[end_of_mangled_name + 1..].trim();

--- a/build.rs
+++ b/build.rs
@@ -42,15 +42,18 @@ fn emit_test_case(spec_line: &str, title_line: &str, output: &mut impl Write) {
             output,
             "  let ast = ::mangled_symbol_to_ast(r#\"{}\"#).unwrap();",
             mangled
-        ).unwrap();
+        )
+        .unwrap();
         writeln!(
             output,
             "  let demangled_actual = ::ast_to_demangled_symbol(&ast);"
-        ).unwrap();
+        )
+        .unwrap();
         writeln!(
             output,
             "  assert_eq!(demangled_expected, demangled_actual);"
-        ).unwrap();
+        )
+        .unwrap();
         writeln!(output, "}}").unwrap();
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let test_case_definitions_path = Path::new("src").join("demangling_test_data.txt");
 
     println!(
-        "cargo:rerun-if-env-changed={}",
+        "cargo:rerun-if-changed={}",
         test_case_definitions_path.to_string_lossy()
     );
 

--- a/build.rs
+++ b/build.rs
@@ -19,46 +19,42 @@ fn main() {
 
     let lines: Vec<_> = test_case_definitions.lines().map(|l| l.unwrap()).collect();
 
-    for i in 1..lines.len() - 1 {
-        if lines[i].starts_with("_R") && lines[i - 1].starts_with('#') {
-            let title_line = &lines[i - 1];
-            let spec_line = &lines[i];
+    for (title_line, spec_line) in lines.iter().zip(lines.iter().skip(1)) {
+        if title_line.starts_with('#') && spec_line.starts_with("_R") {
             emit_test_case(spec_line, title_line, &mut output);
         }
     }
 }
 
 fn emit_test_case(spec_line: &str, title_line: &str, output: &mut impl Write) {
-    if spec_line.starts_with("_R") && title_line.starts_with('#') {
-        let end_of_mangled_name = spec_line.find(' ').unwrap();
-        let mangled = &spec_line[..end_of_mangled_name];
-        let demangled = spec_line[end_of_mangled_name + 1..].trim();
+    let end_of_mangled_name = spec_line.find(' ').unwrap();
+    let mangled = &spec_line[..end_of_mangled_name];
+    let demangled = spec_line[end_of_mangled_name + 1..].trim();
 
-        let title = title_line[1..]
-            .trim()
-            .replace(" ", "_")
-            .replace("/", "_")
-            .replace(",", "_")
-            .replace("-", "_");
+    let title = title_line[1..]
+        .trim()
+        .replace(" ", "_")
+        .replace("/", "_")
+        .replace(",", "_")
+        .replace("-", "_");
 
-        writeln!(output, "#[test] #[allow(non_snake_case)] fn {}() {{", title).unwrap();
-        writeln!(output, "  let demangled_expected = r#\"{}\"#;", demangled).unwrap();
-        writeln!(
-            output,
-            "  let ast = ::mangled_symbol_to_ast(r#\"{}\"#).unwrap();",
-            mangled
-        )
-        .unwrap();
-        writeln!(
-            output,
-            "  let demangled_actual = ::ast_to_demangled_symbol(&ast);"
-        )
-        .unwrap();
-        writeln!(
-            output,
-            "  assert_eq!(demangled_expected, demangled_actual);"
-        )
-        .unwrap();
-        writeln!(output, "}}").unwrap();
-    }
+    writeln!(output, "#[test] #[allow(non_snake_case)] fn {}() {{", title).unwrap();
+    writeln!(output, "  let demangled_expected = r#\"{}\"#;", demangled).unwrap();
+    writeln!(
+        output,
+        "  let ast = ::mangled_symbol_to_ast(r#\"{}\"#).unwrap();",
+        mangled
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  let demangled_actual = ::ast_to_demangled_symbol(&ast);"
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  assert_eq!(demangled_expected, demangled_actual);"
+    )
+    .unwrap();
+    writeln!(output, "}}").unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,11 @@ fn main() {
 
     let test_case_definitions_path = Path::new("src").join("demangling_test_data.txt");
 
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        test_case_definitions_path.to_string_lossy()
+    );
+
     let test_case_definitions = BufReader::new(File::open(test_case_definitions_path).unwrap());
 
     let lines: Vec<_> = test_case_definitions.lines().map(|l| l.unwrap()).collect();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,12 +20,31 @@ pub struct Namespace(pub u8);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Path {
-    CrateRoot { id: Ident },
-    InherentImpl { impl_path: ImplPath, self_type: Type },
-    TraitImpl { impl_path: ImplPath, self_type: Type, trait_name: Arc<Path> },
-    TraitDef { self_type: Type, trait_name: Arc<Path> },
-    Nested { ns: Namespace, inner: Arc<Path>, ident: Ident },
-    Generic { inner: Arc<Path>, args: Vec<GenericArg> },
+    CrateRoot {
+        id: Ident,
+    },
+    InherentImpl {
+        impl_path: ImplPath,
+        self_type: Type,
+    },
+    TraitImpl {
+        impl_path: ImplPath,
+        self_type: Type,
+        trait_name: Arc<Path>,
+    },
+    TraitDef {
+        self_type: Type,
+        trait_name: Arc<Path>,
+    },
+    Nested {
+        ns: Namespace,
+        inner: Arc<Path>,
+        ident: Ident,
+    },
+    Generic {
+        inner: Arc<Path>,
+        args: Vec<GenericArg>,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/ast_demangle.rs
+++ b/src/ast_demangle.rs
@@ -75,7 +75,7 @@ impl AstDemangle for Path {
 
                 if *ns == Namespace(b'C') {
                     write!(out, "::{{closure}}[{}]", ident.dis.0).unwrap();
-                } else if ident.u_ident.0.len() > 0 {
+                } else if !ident.u_ident.0.is_empty() {
                     out.push_str("::");
                     ident.demangle_to_string(out);
                 }
@@ -101,7 +101,7 @@ impl AstDemangle for DynBounds {
     fn demangle_to_string(&self, out: &mut String) {
         for tr in self.traits.iter() {
             tr.demangle_to_string(out);
-            out.push_str("+");
+            out.push('+');
         }
 
         out.pop();
@@ -137,31 +137,31 @@ impl AstDemangle for Type {
                 bt.demangle_to_string(out);
             }
             Type::Array(ref inner, ref len) => {
-                out.push_str("[");
+                out.push('[');
                 inner.demangle_to_string(out);
                 out.push_str("; ");
                 len.demangle_to_string(out);
-                out.push_str("]");
+                out.push(']');
             }
             Type::Slice(ref inner) => {
-                out.push_str("[");
+                out.push('[');
                 inner.demangle_to_string(out);
-                out.push_str("]");
+                out.push(']');
             }
             Type::Named(ref path) => {
                 path.demangle_to_string(out);
             }
             Type::Tuple(ref inner) => {
-                out.push_str("(");
+                out.push('(');
                 for ty in inner {
                     ty.demangle_to_string(out);
-                    out.push_str(",");
+                    out.push(',');
                 }
                 out.pop();
-                out.push_str(")");
+                out.push(')');
             }
             Type::Ref(_, ref ty) => {
-                out.push_str("&");
+                out.push('&');
                 ty.demangle_to_string(out);
             }
             Type::RefMut(_, ref ty) => {
@@ -195,20 +195,20 @@ impl AstDemangle for FnSig {
         if let Some(ref abi) = self.abi {
             out.push_str("extern ");
             abi.demangle_to_string(out);
-            out.push_str(" ");
+            out.push(' ');
         }
 
         out.push_str("fn(");
 
-        if self.param_types.len() > 0 {
+        if !self.param_types.is_empty() {
             for param_type in self.param_types.iter() {
                 param_type.demangle_to_string(out);
-                out.push_str(",");
+                out.push(',');
             }
             out.pop();
         }
 
-        out.push_str(")");
+        out.push(')');
 
         if self.return_type != Type::BasicType(BasicType::Unit) {
             out.push_str(" -> ");
@@ -236,7 +236,7 @@ impl AstDemangle for DynTrait {
     fn demangle_to_string(&self, out: &mut String) {
         self.path.demangle_to_string(out);
 
-        if self.assoc_type_bindings.len() > 0 {
+        if !self.assoc_type_bindings.is_empty() {
             out.push('<');
 
             for binding in self.assoc_type_bindings.iter() {

--- a/src/ast_demangle.rs
+++ b/src/ast_demangle.rs
@@ -24,7 +24,6 @@ impl AstDemangle for Symbol {
 
 impl AstDemangle for Ident {
     fn demangle_to_string(&self, out: &mut String) {
-
         self.u_ident.demangle_to_string(out);
         if self.dis != Base62Number(0) {
             write!(out, "[{}]", self.dis.0).unwrap();
@@ -44,20 +43,34 @@ impl AstDemangle for Path {
             Path::CrateRoot { ref id } => {
                 id.demangle_to_string(out);
             }
-            Path::InherentImpl { impl_path: _, ref self_type } => {
+            Path::InherentImpl {
+                impl_path: _,
+                ref self_type,
+            } => {
                 out.push('<');
                 self_type.demangle_to_string(out);
                 out.push('>');
             }
-            Path::TraitImpl { impl_path: _, ref self_type, ref trait_name } |
-            Path::TraitDef { ref self_type, ref trait_name } => {
+            Path::TraitImpl {
+                impl_path: _,
+                ref self_type,
+                ref trait_name,
+            }
+            | Path::TraitDef {
+                ref self_type,
+                ref trait_name,
+            } => {
                 out.push('<');
                 self_type.demangle_to_string(out);
                 out.push_str(" as ");
                 trait_name.demangle_to_string(out);
                 out.push('>');
             }
-            Path::Nested { ref ns, ref inner, ref ident } => {
+            Path::Nested {
+                ref ns,
+                ref inner,
+                ref ident,
+            } => {
                 inner.demangle_to_string(out);
 
                 if *ns == Namespace(b'C') {
@@ -67,7 +80,10 @@ impl AstDemangle for Path {
                     ident.demangle_to_string(out);
                 }
             }
-            Path::Generic { ref inner, ref args } => {
+            Path::Generic {
+                ref inner,
+                ref args,
+            } => {
                 inner.demangle_to_string(out);
                 out.push('<');
                 for arg in args {
@@ -78,7 +94,6 @@ impl AstDemangle for Path {
                 out.push('>');
             }
         }
-
     }
 }
 
@@ -153,7 +168,7 @@ impl AstDemangle for Type {
                 out.push_str("&mut ");
                 ty.demangle_to_string(out);
             }
-            Type::RawPtrConst(ref ty)  => {
+            Type::RawPtrConst(ref ty) => {
                 out.push_str("*const ");
                 ty.demangle_to_string(out);
             }
@@ -167,7 +182,6 @@ impl AstDemangle for Type {
             Type::DynTrait(ref bounds, _) => {
                 bounds.demangle_to_string(out);
             }
-
         }
     }
 }
@@ -218,7 +232,6 @@ impl AstDemangle for Abi {
     }
 }
 
-
 impl AstDemangle for DynTrait {
     fn demangle_to_string(&self, out: &mut String) {
         self.path.demangle_to_string(out);
@@ -234,7 +247,6 @@ impl AstDemangle for DynTrait {
             out.pop();
             out.push('>');
         }
-
     }
 }
 
@@ -249,22 +261,21 @@ impl AstDemangle for DynTraitAssocBinding {
 impl AstDemangle for Const {
     fn demangle_to_string(&self, out: &mut String) {
         match *self {
-            Const::Value(Type::BasicType(BasicType::I8), i) |
-            Const::Value(Type::BasicType(BasicType::I16), i) |
-            Const::Value(Type::BasicType(BasicType::I32), i) |
-            Const::Value(Type::BasicType(BasicType::I64), i) |
-            Const::Value(Type::BasicType(BasicType::I128), i) |
-            Const::Value(Type::BasicType(BasicType::Isize), i) |
-            Const::Value(Type::BasicType(BasicType::U8), i) |
-            Const::Value(Type::BasicType(BasicType::U16), i) |
-            Const::Value(Type::BasicType(BasicType::U32), i) |
-            Const::Value(Type::BasicType(BasicType::U64), i) |
-            Const::Value(Type::BasicType(BasicType::U128), i) |
-            Const::Value(Type::BasicType(BasicType::Usize), i) => {
+            Const::Value(Type::BasicType(BasicType::I8), i)
+            | Const::Value(Type::BasicType(BasicType::I16), i)
+            | Const::Value(Type::BasicType(BasicType::I32), i)
+            | Const::Value(Type::BasicType(BasicType::I64), i)
+            | Const::Value(Type::BasicType(BasicType::I128), i)
+            | Const::Value(Type::BasicType(BasicType::Isize), i)
+            | Const::Value(Type::BasicType(BasicType::U8), i)
+            | Const::Value(Type::BasicType(BasicType::U16), i)
+            | Const::Value(Type::BasicType(BasicType::U32), i)
+            | Const::Value(Type::BasicType(BasicType::U64), i)
+            | Const::Value(Type::BasicType(BasicType::U128), i)
+            | Const::Value(Type::BasicType(BasicType::Usize), i) => {
                 write!(out, "{}", i).unwrap();
             }
-            Const::Placeholder(ref ty) |
-            Const::Value(ref ty, _) => {
+            Const::Placeholder(ref ty) | Const::Value(ref ty, _) => {
                 out.push_str("{const ");
                 ty.demangle_to_string(out);
                 out.push('}');

--- a/src/bin/rust-filt.rs
+++ b/src/bin/rust-filt.rs
@@ -1,13 +1,11 @@
-
 extern crate std_mangle_rs;
 
-use std_mangle_rs::{mangled_symbol_to_ast, ast_to_demangled_symbol};
+use std_mangle_rs::{ast_to_demangled_symbol, mangled_symbol_to_ast};
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
 
     if args.len() >= 2 {
-
         let ast = mangled_symbol_to_ast(&args[1]).unwrap();
         let demangled = ast_to_demangled_symbol(&ast);
         println!("{}", demangled);

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,8 @@ pub fn expected<T>(
             "{} or {}",
             char_to_str(expected_chars[0]),
             char_to_str(expected_chars[1])
-        ).unwrap();
+        )
+        .unwrap();
     } else {
         for i in 0..expected_chars.len() - 1 {
             write!(message, "{}, ", char_to_str(expected_chars[i])).unwrap();
@@ -30,7 +31,8 @@ pub fn expected<T>(
             message,
             "or {}",
             char_to_str(expected_chars[expected_chars.len() - 1])
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     write!(
@@ -39,7 +41,8 @@ pub fn expected<T>(
         char_to_str(found_char as char),
         verb,
         noun
-    ).unwrap();
+    )
+    .unwrap();
 
     Err(message)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub fn expected<T>(
 ) -> Result<T, String> {
     let expected_chars = expected_chars.chars().collect::<Vec<_>>();
 
-    assert!(expected_chars.len() > 0);
+    assert!(!expected_chars.is_empty());
 
     let mut message = "Expected ".to_string();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,8 +23,8 @@ pub fn expected<T>(
         )
         .unwrap();
     } else {
-        for i in 0..expected_chars.len() - 1 {
-            write!(message, "{}, ", char_to_str(expected_chars[i])).unwrap();
+        for &c in expected_chars.iter().take(expected_chars.len() - 1) {
+            write!(message, "{}, ", char_to_str(c)).unwrap();
         }
 
         write!(

--- a/src/int_radix.rs
+++ b/src/int_radix.rs
@@ -59,12 +59,12 @@ mod tests {
 
     #[test]
     fn ascii_digit_to_value_cross_check() {
-        for i in 0..DIGITS.len() {
+        for (i, &d) in DIGITS.iter().enumerate() {
             for radix in 0..DIGITS.len() {
                 if i < radix {
-                    assert_eq!(Some(i as u64), ascii_digit_to_value(DIGITS[i], radix as u8));
+                    assert_eq!(Some(i as u64), ascii_digit_to_value(d, radix as u8));
                 } else {
-                    assert_eq!(None, ascii_digit_to_value(DIGITS[i], radix as u8));
+                    assert_eq!(None, ascii_digit_to_value(d, radix as u8));
                 }
             }
         }

--- a/src/int_radix.rs
+++ b/src/int_radix.rs
@@ -15,7 +15,7 @@ impl fmt::Display for RadixFmt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let RadixFmt { radix, mut value } = *self;
 
-        assert!(radix >= 2 && radix <= 62);
+        assert!((2..=62).contains(&radix));
 
         if value == 0 {
             write!(f, "0")?;
@@ -26,7 +26,7 @@ impl fmt::Display for RadixFmt {
 
         while value > 0 {
             let digit = value % radix;
-            value = value / radix;
+            value /= radix;
             text.push(DIGITS[digit as usize]);
         }
 
@@ -89,7 +89,7 @@ mod tests {
 
     quickcheck! {
         fn radix_fmt_vs_std(value: u64, base: u8) -> bool {
-            if base < 2 || base > 36 {
+            if !(2..=36).contains(&base) {
                 return true
             }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -392,7 +392,6 @@ impl<'input> Parser<'input> {
         }
     }
 
-    #[must_use]
     fn eat(&mut self, c: u8, noun: &str) -> Result<(), String> {
         if self.cur() != c {
             return expected(str::from_utf8(&[c]).unwrap(), self.cur(), "parsing", noun);
@@ -412,7 +411,6 @@ impl<'input> Parser<'input> {
         }
     }
 
-    #[must_use]
     fn parse_number(&mut self, radix: u8) -> Result<u64, String> {
         if ascii_digit_to_value(self.cur(), radix).is_none() {
             return Err(format!(
@@ -432,7 +430,6 @@ impl<'input> Parser<'input> {
         Ok(value)
     }
 
-    #[must_use]
     fn parse_backref(&mut self) -> Result<Parser<'input>, String> {
         let Base62Number(pos) = self.parse_base62_number()?;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -23,7 +23,7 @@ pub struct Parser<'input> {
 impl<'input> Parser<'input> {
     fn parse_symbol(&mut self) -> Result<Symbol, String> {
         if &self.input[0..2] != b"_R" {
-            return Err(format!("Not a Rust symbol"));
+            return Err("Not a Rust symbol".to_string());
         }
 
         self.pos += 2;
@@ -352,7 +352,7 @@ impl<'input> Parser<'input> {
         let end = start + num_bytes as usize;
 
         if end > self.input.len() {
-            return Err(format!("identifier extend beyond end of input"));
+            return Err("identifier extend beyond end of input".to_string());
         }
 
         self.pos = end;


### PR DESCRIPTION
This PR contains:

1. `cargo fmt`;
2. `cargo clippy --fix -Z unstable-options`;
3. Manual fix for other Clippy warnings;
4. Detect test data updates according to <https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed>.